### PR TITLE
Update inch_ex to 0.3.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Mt940.Mixfile do
       {:excoveralls, "~> 0.3", only: [:dev, :test]},
       {:earmark,     "~> 0.1", only: :dev},
       {:ex_doc,      "~> 0.7", only: :dev},
-      {:inch_ex,     "~> 0.2", only: :docs},
+      {:inch_ex,     "~> 0.3", only: :docs},
       {:timex,       "~> 0.13.4"}
     ]
   end


### PR DESCRIPTION
Hi Florian,

your badge is working now. There was a bug I did not catch on my own, so thank you very much for the heads-up!

I updated your `mix.exs` to point to the new `0.3.x` releases, so you get the patched version. You could also simply omit the version number completely to always run the newest release of InchEx.

Thanks again! :+1:
